### PR TITLE
Move openssl.cnf to to make sure things are configured immediately

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+openssl (3.0.8-0pexip2) pexip; urgency=medium
+
+  * Move openssl.cnf to make sure things are configured immediately
+    on installation of libssl3:
+    + Move from /etc/ssl to /usr/lib/ssl. We never need to change
+      things here, so let's avoid conffile handling.
+    + Move from the openssl binary package to libssl3, as libssl3
+      hard-depends on working config here if we're in FIPS mode.
+  * Add Replaces/Breaks to make things work on upgrade
+
+ -- Steve McIntyre <steve.mcintyre@pexip.com>  Tue, 14 Mar 2023 18:34:38 +0000
+
 openssl (3.0.8-0pexip1) pexip; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ XS-Pexip-Upstream: http://ftp.debian.org/debian/ experimental
 Package: openssl
 Architecture: any
 Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${perl:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${perl:Depends}, ${misc:Depends}, libssl3 (>= 3.0.8-0pexip2)
 Suggests: ca-certificates
 Description: Secure Sockets Layer toolkit - cryptographic utility
  This package is part of the OpenSSL project's implementation of the SSL
@@ -37,6 +37,8 @@ Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}, libssl3-fips
+Replaces: openssl (<< 3.0.8-0pexip2)
+Breaks: openssl (<< 3.0.8-0pexip2)
 Description: Secure Sockets Layer toolkit - shared libraries
  This package is part of the OpenSSL project's implementation of the SSL
  and TLS cryptographic protocols for secure communication over the

--- a/debian/rules
+++ b/debian/rules
@@ -116,12 +116,13 @@ override_dh_auto_install-arch:
 	cp -pf build_static/libcrypto.a debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/libcrypto.a
 	cp -pf build_static/libssl.a debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/libssl.a
 	mkdir -p debian/tmp/etc/ssl
-	mv debian/tmp/usr/lib/ssl/{certs,openssl.cnf,private} debian/tmp/etc/ssl/
-	ln -s /etc/ssl/{certs,openssl.cnf,private} debian/tmp/usr/lib/ssl/
+	mv debian/tmp/usr/lib/ssl/{certs,private} debian/tmp/etc/ssl/
+	ln -s /etc/ssl/{certs,private} debian/tmp/usr/lib/ssl/
+	ln -s /usr/lib/ssl/openssl.cnf debian/tmp/etc/ssl
 	cp -pf debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/libcrypto.so.* debian/libcrypto3-udeb/usr/lib/
 	cp -pf debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/ossl-modules/*.so debian/libcrypto3-udeb/usr/lib/ossl-modules
-	cp -pf debian/tmp/etc/ssl/openssl.cnf debian/libcrypto3-udeb/usr/lib/ssl/openssl.cnf
-	sed -i -e 's/^# .include fipsmodule.cnf/.include \/etc\/ssl\/fipsmodule.cnf/' -e 's/^# fips = fips_sect/fips = fips_sect/' debian/tmp/etc/ssl/openssl.cnf
+	cp -pf debian/tmp/usr/lib/ssl/openssl.cnf debian/libcrypto3-udeb/usr/lib/ssl/openssl.cnf
+	sed -i -e 's/^# .include fipsmodule.cnf/.include \/usr\/lib\/ssl\/fipsmodule.cnf/' -e 's/^# fips = fips_sect/fips = fips_sect/' debian/tmp/usr/lib/ssl/openssl.cnf
 	cp -pf debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/libssl.so.* debian/libssl3-udeb/usr/lib/
 	cp -auv build_shared/lib*.so* debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/
 	for opt in $(OPTS); \


### PR DESCRIPTION
* Move from /etc/ssl to /usr/lib/ssl. We never need to change things here, so let's avoid conffile handling.

* Move from the openssl binary package to libssl3, as libssl3 hard-depends on working config here if we're in FIPS mode.

Add Replaces/Breaks to make things work on upgrade

Work towards #32913